### PR TITLE
fix: update pyx link

### DIFF
--- a/app/graph-tool.md
+++ b/app/graph-tool.md
@@ -12,7 +12,7 @@ draft: false
 
 ## Graphics language 
 - [Asymptote](https://asymptote.sourceforge.io/)
-- [PyX](https://en.wikipedia.org/wiki/PyX_(vector_graphics_language))
+- [PyX](https://en.wikipedia.org/wiki/PyX_\(vector_graphics_language\))
 - [Tikz](https://github.com/pgf-tikz/pgf)
 - [PSTricks](https://en.wikipedia.org/wiki/PSTricks)
 


### PR DESCRIPTION
Escaping broken URL here, which was valid in GitHub but not GitBook.

https://irosyadi.gitbook.io/irosyadi/app/graph-tool

<img width="579" alt="Screen Shot 2021-06-08 at 4 45 10 pm" src="https://user-images.githubusercontent.com/18750745/121206618-e9425000-c878-11eb-83b3-a67acad5314f.png">

When using _with_ brackets, GitHub renders the URL fine. I don't have GitBook set up so you'll need to verify this on your end please.
